### PR TITLE
kernel: in favor of UpdateReader

### DIFF
--- a/src/kernel/src/kernel.rs
+++ b/src/kernel/src/kernel.rs
@@ -15,7 +15,7 @@
 use engula_futures::io::{RandomRead, SequentialWrite};
 use engula_journal::{StreamReader, StreamWriter};
 
-use crate::{async_trait, KernelUpdate, Result, Sequence};
+use crate::{async_trait, metadata::PartialKernelUpdate, KernelUpdate, Result, Sequence};
 
 /// A stateful environment for storage engines.
 #[async_trait]
@@ -26,6 +26,11 @@ pub trait Kernel {
     type StreamWriter: StreamWriter;
     type RandomReader: RandomRead;
     type SequentialWriter: SequentialWrite;
+
+    async fn create_stream(&self, stream_name: &str) -> Result<()>;
+    async fn delete_stream(&self, stream_name: &str) -> Result<()>;
+    async fn create_bucket(&self, bucket_name: &str) -> Result<()>;
+    async fn delete_bucket(&self, bucket_name: &str) -> Result<()>;
 
     /// Returns a reader to read updates.
     async fn new_update_reader(&self) -> Result<Self::UpdateReader>;
@@ -64,7 +69,7 @@ pub trait UpdateReader {
 #[async_trait]
 pub trait UpdateWriter {
     /// Appends an update.
-    async fn append(&mut self, update: KernelUpdate) -> Result<Sequence>;
+    async fn append(&mut self, update: PartialKernelUpdate) -> Result<Sequence>;
 
     /// Releases updates up to a sequence (exclusive).
     ///

--- a/src/kernel/src/local/kernel.rs
+++ b/src/kernel/src/local/kernel.rs
@@ -19,7 +19,7 @@ use engula_storage::Storage;
 use tokio::sync::broadcast;
 
 use super::{update_reader::UpdateReader, update_writer::UpdateWriter};
-use crate::{async_trait, KernelUpdate, Result, Sequence};
+use crate::{async_trait, KernelUpdate, Result, Sequence, UpdateReader as _};
 
 pub struct Kernel<J, S> {
     journal: Arc<J>,
@@ -28,30 +28,58 @@ pub struct Kernel<J, S> {
     update_tx: broadcast::Sender<(Sequence, KernelUpdate)>,
 }
 
-impl<J, S> Kernel<J, S> {
+impl<J, S> Kernel<J, S>
+where
+    J: Journal + Send + Sync + 'static,
+    S: Storage + Send + Sync + 'static,
+{
     pub async fn init(journal: J, storage: S) -> Result<Self> {
-        let (update_tx, _) = broadcast::channel(1024);
+        let (update_tx, update_rx) = broadcast::channel(1024);
+        let journal = Arc::new(journal);
+        let storage = Arc::new(storage);
+        let reader = UpdateReader::new(update_rx);
+        Self::subscribe_updates(reader, journal.clone(), storage.clone());
         Ok(Self {
-            journal: Arc::new(journal),
-            storage: Arc::new(storage),
+            journal,
+            storage,
             sequence: Arc::new(AtomicU64::new(0)),
             update_tx,
         })
+    }
+
+    fn subscribe_updates(mut reader: UpdateReader, journal: Arc<J>, storage: Arc<S>) {
+        tokio::spawn(async move {
+            loop {
+                let (_, update) = reader.wait_next().await.unwrap();
+                for stream in &update.add_streams {
+                    journal.create_stream(stream).await.unwrap();
+                }
+                for stream in &update.remove_streams {
+                    journal.delete_stream(stream).await.unwrap();
+                }
+                for bucket in &update.add_buckets {
+                    storage.create_bucket(bucket).await.unwrap();
+                }
+                for bucket in &update.remove_buckets {
+                    storage.delete_bucket(bucket).await.unwrap();
+                }
+            }
+        });
     }
 }
 
 #[async_trait]
 impl<J, S> crate::Kernel for Kernel<J, S>
 where
-    J: Journal + Send + Sync,
-    S: Storage + Send + Sync,
+    J: Journal + Send + Sync + 'static,
+    S: Storage + Send + Sync + 'static,
 {
     type RandomReader = S::RandomReader;
     type SequentialWriter = S::SequentialWriter;
     type StreamReader = J::StreamReader;
     type StreamWriter = J::StreamWriter;
     type UpdateReader = UpdateReader;
-    type UpdateWriter = UpdateWriter<J, S>;
+    type UpdateWriter = UpdateWriter;
 
     async fn new_update_reader(&self) -> Result<Self::UpdateReader> {
         let reader = UpdateReader::new(self.update_tx.subscribe());
@@ -59,12 +87,7 @@ where
     }
 
     async fn new_update_writer(&self) -> Result<Self::UpdateWriter> {
-        let writer = UpdateWriter::new(
-            self.journal.clone(),
-            self.storage.clone(),
-            self.sequence.clone(),
-            self.update_tx.clone(),
-        );
+        let writer = UpdateWriter::new(self.sequence.clone(), self.update_tx.clone());
         Ok(writer)
     }
 

--- a/src/kernel/src/local/update_writer.rs
+++ b/src/kernel/src/local/update_writer.rs
@@ -17,58 +17,24 @@ use std::sync::{
     Arc,
 };
 
-use engula_journal::Journal;
-use engula_storage::Storage;
 use tokio::sync::broadcast::Sender;
 
 use crate::{async_trait, Error, KernelUpdate, Result, Sequence, UpdateEvent};
 
-pub struct UpdateWriter<J, S> {
-    journal: Arc<J>,
-    storage: Arc<S>,
+pub struct UpdateWriter {
     sequence: Arc<AtomicU64>,
     tx: Sender<UpdateEvent>,
 }
 
-impl<J, S> UpdateWriter<J, S>
-where
-    J: Journal,
-    S: Storage,
-{
-    pub fn new(
-        journal: Arc<J>,
-        storage: Arc<S>,
-        sequence: Arc<AtomicU64>,
-        tx: Sender<UpdateEvent>,
-    ) -> Self {
-        Self {
-            journal,
-            storage,
-            sequence,
-            tx,
-        }
+impl UpdateWriter {
+    pub fn new(sequence: Arc<AtomicU64>, tx: Sender<UpdateEvent>) -> Self {
+        Self { sequence, tx }
     }
 }
 
 #[async_trait]
-impl<J, S> crate::UpdateWriter for UpdateWriter<J, S>
-where
-    J: Journal + Send + Sync,
-    S: Storage + Send + Sync,
-{
+impl crate::UpdateWriter for UpdateWriter {
     async fn append(&mut self, update: KernelUpdate) -> Result<Sequence> {
-        for stream in &update.add_streams {
-            self.journal.create_stream(stream).await?;
-        }
-        for stream in &update.remove_streams {
-            self.journal.delete_stream(stream).await?;
-        }
-        for bucket in &update.add_buckets {
-            self.storage.create_bucket(bucket).await?;
-        }
-        for bucket in &update.remove_buckets {
-            self.storage.delete_bucket(bucket).await?;
-        }
         let sequence = self.sequence.fetch_add(1, Ordering::SeqCst) + 1;
         self.tx.send((sequence, update)).map_err(Error::unknown)?;
         Ok(sequence)

--- a/src/kernel/src/local/update_writer.rs
+++ b/src/kernel/src/local/update_writer.rs
@@ -19,7 +19,7 @@ use std::sync::{
 
 use tokio::sync::broadcast::Sender;
 
-use crate::{async_trait, Error, KernelUpdate, Result, Sequence, UpdateEvent};
+use crate::{async_trait, metadata::PartialKernelUpdate, Error, Result, Sequence, UpdateEvent};
 
 pub struct UpdateWriter {
     sequence: Arc<AtomicU64>,
@@ -34,9 +34,11 @@ impl UpdateWriter {
 
 #[async_trait]
 impl crate::UpdateWriter for UpdateWriter {
-    async fn append(&mut self, update: KernelUpdate) -> Result<Sequence> {
+    async fn append(&mut self, update: PartialKernelUpdate) -> Result<Sequence> {
         let sequence = self.sequence.fetch_add(1, Ordering::SeqCst) + 1;
-        self.tx.send((sequence, update)).map_err(Error::unknown)?;
+        self.tx
+            .send((sequence, update.into()))
+            .map_err(Error::unknown)?;
         Ok(sequence)
     }
 

--- a/src/kernel/src/metadata.proto
+++ b/src/kernel/src/metadata.proto
@@ -21,6 +21,12 @@ message BucketUpdate {
   repeated string remove_objects = 2;
 }
 
+message PartialKernelUpdate {
+  map<string, bytes> put_meta = 1;
+  repeated string remove_meta = 2;
+  map<string, BucketUpdate> update_buckets = 3;
+}
+
 message KernelUpdate {
   map<string, bytes> put_meta = 1;
   repeated string remove_meta = 2;

--- a/src/kernel/src/metadata.rs
+++ b/src/kernel/src/metadata.rs
@@ -16,4 +16,4 @@ pub mod v1 {
     tonic::include_proto!("engula.metadata.v1");
 }
 
-pub use v1::{BucketUpdate, KernelUpdate};
+pub use v1::{BucketUpdate, KernelUpdate, PartialKernelUpdate};


### PR DESCRIPTION
Signed-off-by: tison <wander4096@gmail.com>

From API design perspective, let the `Kernel` subscribe the updates itself is more intuitive and elegant.

See also https://github.com/engula/engula/pull/273